### PR TITLE
Fixed cookie lookup (probably a hack)

### DIFF
--- a/voice.js
+++ b/voice.js
@@ -173,7 +173,7 @@ exports.Client.prototype.rnr = function(callback, isRepeat){
 
 
 var getCookie = function(jar, name){
-	var parts = ['store', 'idx', 'www.google.com', '/voice', name];
+	var parts = ['_jar', 'store', 'idx', 'www.google.com', '/voice', name];
 	var obj = jar;
 	while (obj && parts.length) {
 		obj = obj[parts.shift()];


### PR DESCRIPTION
After the most recent changes and an `npm install`, I couldn't run the examples ([gist](https://gist.github.com/mynnx/8593486)) and my application was running out of memory.

This seemed to fix it.  If others confirm that they have the same problem, I'll look into it a little deeper.
